### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ PerfectAudience.prototype.track = function(track) {
 };
 
 /**
- * Viewed Product.
+ * Product viewed.
  *
  * http://support.perfectaudience.com/knowledgebase/articles/212490-visitor-tracking-api
  *
@@ -77,7 +77,7 @@ PerfectAudience.prototype.track = function(track) {
  * @param {Track} track
  */
 
-PerfectAudience.prototype.viewedProduct = function(track) {
+PerfectAudience.prototype.productViewed = function(track) {
   var product = track.id() || track.sku();
   push('track', track.event());
   push('trackProduct', product);
@@ -92,7 +92,7 @@ PerfectAudience.prototype.viewedProduct = function(track) {
  * @param {Track} track
  */
 
-PerfectAudience.prototype.completedOrder = function(track) {
+PerfectAudience.prototype.orderCompleted = function(track) {
   var total = track.total() || track.revenue();
   var orderId = track.orderId();
   var props = {};

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-perfect-audience#readme",
   "dependencies": {
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.1.0",
     "global-queue": "^1.0.1"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/analytics.js-integration-tester": "^3.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "^13.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,42 +88,42 @@ describe('Perfect Audience', function() {
       });
     });
 
-    describe('#viewedProduct', function() {
+    describe('#productViewed', function() {
       beforeEach(function() {
         analytics.stub(window._pq, 'push');
       });
 
       it('should send a track and a trackProduct with product ID', function() {
-        analytics.track('Viewed Product', {
+        analytics.track('Product Viewed', {
           id: '507f1f77bcf86cd799439011',
           sku: '45790-32',
           name: 'Monopoly: 3rd Edition',
           price: 18.99,
           category: 'Games'
         });
-        analytics.called(window._pq.push, ['track', 'Viewed Product']);
+        analytics.called(window._pq.push, ['track', 'Product Viewed']);
         analytics.called(window._pq.push, ['trackProduct', '507f1f77bcf86cd799439011']);
       });
 
       it('should send a track and a trackProduct with product SKU, if there is not product ID', function() {
-        analytics.track('Viewed Product', {
+        analytics.track('Product Viewed', {
           sku: '45790-32',
           name: 'Monopoly: 3rd Edition',
           price: 18.99,
           category: 'Games'
         });
-        analytics.called(window._pq.push, ['track', 'Viewed Product']);
+        analytics.called(window._pq.push, ['track', 'Product Viewed']);
         analytics.called(window._pq.push, ['trackProduct', '45790-32']);
       });
     });
 
-    describe('#completedOrder', function() {
+    describe('#orderCompleted', function() {
       beforeEach(function() {
         analytics.stub(window._pq, 'push');
       });
 
       it('should send event and orderId, revenue properties', function() {
-        analytics.track('Completed Order', {
+        analytics.track('Order Completed', {
           orderId: '12345',
           total: 30,
           revenue: 25,
@@ -151,7 +151,7 @@ describe('Perfect Audience', function() {
             }
           ]
         });
-        analytics.called(window._pq.push, ['track', 'Completed Order', { orderId: '12345', revenue: 30 }]);
+        analytics.called(window._pq.push, ['track', 'Order Completed', { orderId: '12345', revenue: 30 }]);
       });
     });
   });


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

Tests are failing because it isn't properly aliasing against the new spec'd events. These tests will need to pass, dependent on a new version of Analytics Events and Analytics.js-Private before being merged.
