### PR TITLE
Use marinsm.com

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ var PerfectAudience = module.exports = integration('Perfect Audience')
   .assumesPageview()
   .global('_pq')
   .option('siteId', '')
-  .tag('<script src="//tag.perfectaudience.com/serve/{{ siteId }}.js">');
+  .tag('<script src="//tag.marinsm.com/serve/{{ siteId }}.js">');
 
 /**
  * Initialize.


### PR DESCRIPTION
I recently noticed that PerfectAudience was running slow, and it seemed to be pulling data from a bunch of domains.  I had a look at a PA, and the [official docs](http://support.perfectaudience.com/knowledgebase/articles/211506-step-1-install-the-site-tracking-tag) use marnism.com domain instead of perfectaudience.com . 

I hope this will fix the extra redirects that I saw. 
